### PR TITLE
job links / Gerrit terminology / dark theme visibility

### DIFF
--- a/zuul-results-summary/zuul-results-summary.js
+++ b/zuul-results-summary/zuul-results-summary.js
@@ -73,7 +73,7 @@ class ZuulSummaryStatusTab extends Polymer.Element {
   </style>
 
   <template is="dom-repeat" items="[[__table]]">
-   <div style="padding-left:5px">
+   <div style="padding-left:5px; padding-bottom:2px;">
    <table>
     <tr>
      <th>

--- a/zuul-results-summary/zuul-results-summary.js
+++ b/zuul-results-summary/zuul-results-summary.js
@@ -79,7 +79,7 @@ class ZuulSummaryStatusTab extends Polymer.Element {
      <th>
       <template is="dom-if" if="{{item.succeeded}}"><span style="color:green"><iron-icon icon="gr-icons:check"></iron-icon></span></template>
       <template is="dom-if" if="{{!item.succeeded}}"><span style="color:red"><iron-icon icon="gr-icons:close"></iron-icon></span></template>
-      <b>[[item.author_name]]</b> on revision <b>[[item.revision]]</b> in pipeline <b>[[item.pipeline]]</b></th>
+      <b>[[item.author_name]]</b> on Patchset <b>[[item.revision]]</b> in pipeline <b>[[item.pipeline]]</b></th>
      <th><template is="dom-if" if="{{item.rechecks}}">[[item.rechecks]] rechecks</template></th>
      <th><b>[[item.date_string]]</b></th>
     </tr>

--- a/zuul-results-summary/zuul-results-summary.js
+++ b/zuul-results-summary/zuul-results-summary.js
@@ -85,7 +85,8 @@ class ZuulSummaryStatusTab extends Polymer.Element {
     </tr>
     <template is="dom-repeat" items="[[item.results]]" as="job">
      <tr>
-      <td><a href="[[job.link]]">[[job.job]]</a></td>
+      <template is="dom-if" if="{{job.link}}"><td><a href="{{job.link}}">[[job.job]]</a></td></template>
+      <template is="dom-if" if="{{!job.link}}"><td><a>[[job.job]]</a></td></template>
       <td><span class$="status-[[job.result]]">[[job.result]]</span></td>
       <td>[[job.time]]</td>
      </tr>
@@ -195,7 +196,7 @@ class ZuulSummaryStatusTab extends Polymer.Element {
       //   - openstack-tox-py35 http://... : SUCCESS in 2m 45
       const results = [];
       const lines = message.message.split('\n');
-      const resultRe = /^- (?<job>[^ ]+) (?<link>[^ ]+) : (?<result>[^ ]+) in (?<time>.*)/;
+      const resultRe = /^- (?<job>[^ ]+) (?:(?<link>https?:\/\/[^ ]+)|[^ ]+) : (?<result>[^ ]+) in (?<time>.*)/;
       lines.forEach(line => {
         const result = resultRe.exec(line);
         if (result) {


### PR DESCRIPTION
Set link only http(s)
Modify table title from "revision" to "Patchset"

![job_links_gerrit_terminology](https://user-images.githubusercontent.com/44832931/101988162-3cf02a00-3c98-11eb-98f5-d9655a6e9d16.png)

Split Zuul Summary and Change log, improve visibility in dark mode
![dark_theme_padding](https://user-images.githubusercontent.com/44832931/101988163-4083b100-3c98-11eb-8e17-451ac8b142b8.png)
